### PR TITLE
Set flag to enable Jacoco Coverage XML generation

### DIFF
--- a/tcp-ballerina/build.gradle
+++ b/tcp-ballerina/build.gradle
@@ -201,7 +201,7 @@ task initializeVariables {
         }
 
         if (graph.hasTask(":${packageName}-ballerina:test")) {
-            testParams = "--code-coverage --includes=*"
+            testParams = "--code-coverage --jacoco-xml --includes=org.ballerinalang.stdlib.tcp.*:ballerina.tcp.*"
         } else {
             testParams = "--skip-tests"
         }


### PR DESCRIPTION
Set flag to enable Jacoco Coverage XML generation. Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30381