### PR TITLE
Fix the secure client initialization failure when ciphers are not configured

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@ This file contains all the notable changes done to the Ballerina TCP package thr
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- [Fix the secure client initialization failure when ciphers are not configured](https://github.com/ballerina-platform/ballerina-standard-library/issues/1569)
+
 ## [0.8.0-beta.1] - 2021-05-06
 
 ### Fixed

--- a/tcp-ballerina/tests/secure_client_test.bal
+++ b/tcp-ballerina/tests/secure_client_test.bal
@@ -197,6 +197,22 @@ function testSecureClientWithEmtyCert() returns @tainted error? {
     }
 }
 
+@test:Config {}
+function testBasicSecureClient() returns error? {
+    Client socketClient = check new ("localhost", 9002, secureSocket = {
+        cert: certPath
+    });
+
+    string msg = "Hello Ballerina basic secure client";
+    byte[] msgByteArray = msg.toBytes();
+    check socketClient->writeBytes(msgByteArray);
+
+   readonly & byte[] receivedData = check socketClient->readBytes();
+   test:assertEquals('string:fromBytes(receivedData), msg, "Found unexpected output");
+
+    check socketClient->close();
+}
+
 @test:AfterSuite {}
 function stopServer() returns error? {
     check stopSecureServer();

--- a/tcp-native/src/main/java/org/ballerinalang/stdlib/tcp/SSLHandlerFactory.java
+++ b/tcp-native/src/main/java/org/ballerinalang/stdlib/tcp/SSLHandlerFactory.java
@@ -133,7 +133,10 @@ public class SSLHandlerFactory {
             initializeTrustManagerFactory();
             sslContextBuilder = clientContextBuilderWithKs(provider);
         }
-        setCiphers(sslContextBuilder, Arrays.asList(this.sslConfig.getCipherSuites()));
+        String[] ciphers = this.sslConfig.getCipherSuites();
+        if (ciphers != null) {
+            setCiphers(sslContextBuilder, Arrays.asList(ciphers));
+        }
         setSslProtocol(sslContextBuilder);
         SslContext sslContext = sslContextBuilder.build();
         int sessionTimeout = sslConfig.getSessionTimeOut();


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1569

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
