### PR TITLE
Introduce Client write timeout

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -82,9 +82,12 @@ public isolated client class Client {
 # + localHost - Local binding of the interface
 # + timeout - The socket reading timeout value to be used in seconds. If this is not set, the default value
 #             of 300 seconds(5 minutes) will be used
+# + writeTimeout - The socket write timeout value to be used in seconds. If this is not set, the default value
+#             of 300 seconds(5 minutes) will be used
 # + secureSocket - The `secureSocket` configuration
 public type ClientConfiguration record {|
     string localHost?;
     decimal timeout = 300;
+    decimal writeTimeout = 300;
     ClientSecureSocket secureSocket?;
 |};

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- [Introduce write time out for TCP client](https://github.com/ballerina-platform/ballerina-standard-library/issues/1684)
+
+## [1.2.0-beta.2] - 2021-07-07
+
 ### Fixed
 - [Fix the secure client initialization failure when ciphers are not configured](https://github.com/ballerina-platform/ballerina-standard-library/issues/1569)
 

--- a/native/src/main/java/io/ballerina/stdlib/tcp/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/tcp/Constants.java
@@ -29,10 +29,12 @@ public class Constants {
     // Constants related to client config
     public static final String CONFIG_LOCALHOST = "localHost";
     public static final String CONFIG_READ_TIMEOUT = "timeout";
+    public static final String CONFIG_WRITE_TIMEOUT = "writeTimeout";
 
     // constant listener handler names
     public static final String LISTENER_HANDLER = "listenerHandler";
     public static final String READ_TIMEOUT_HANDLER = "readTimeoutHandler";
+    public static final String WRITE_TIMEOUT_HANDLER = "writeTimeoutHandler";
     public static final String CLIENT_HANDLER = "clientHandler";
     public static final String SSL_HANDLER = "SSL_Handler";
     public static final String SSL_HANDSHAKE_HANDLER = "SSL_handshakeHandler";

--- a/native/src/main/java/io/ballerina/stdlib/tcp/TcpListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/tcp/TcpListener.java
@@ -116,7 +116,8 @@ public class TcpListener {
     // Invoke when the caller call writeBytes
     public static void send(byte[] bytes, Channel channel, Future callback, TcpService tcpService) {
         if (!tcpService.getIsCallerClosed() && channel.isActive()) {
-            WriteFlowController writeFlowController = new WriteFlowController(Unpooled.wrappedBuffer(bytes), callback);
+            WriteFlowController writeFlowController = new WriteFlowController(Unpooled.wrappedBuffer(bytes), callback,
+                    new AtomicBoolean(false));
             TcpListenerHandler tcpListenerHandler = (TcpListenerHandler) channel.pipeline()
                     .get(Constants.LISTENER_HANDLER);
             tcpListenerHandler.addWriteFlowControl(writeFlowController);

--- a/native/src/main/java/io/ballerina/stdlib/tcp/nativeclient/Client.java
+++ b/native/src/main/java/io/ballerina/stdlib/tcp/nativeclient/Client.java
@@ -60,6 +60,9 @@ public class Client {
 
         double timeout = ((BDecimal) config.get(StringUtils.fromString(Constants.CONFIG_READ_TIMEOUT))).floatValue();
         client.addNativeData(Constants.CONFIG_READ_TIMEOUT, timeout);
+        double writeTimeout = ((BDecimal) config.get(StringUtils.fromString(Constants.CONFIG_WRITE_TIMEOUT)))
+                .floatValue();
+        client.addNativeData(Constants.CONFIG_WRITE_TIMEOUT, writeTimeout);
         BMap<BString, Object> secureSocket = (BMap<BString, Object>) config.getMapValue(Constants.SECURE_SOCKET);
 
         TcpClient tcpClient = TcpFactory.getInstance().
@@ -82,9 +85,10 @@ public class Client {
     public static Object externWriteBytes(Environment env, BObject client, BArray content) {
         final Future balFuture = env.markAsync();
 
+        double writeTimeOut = (double) client.getNativeData(Constants.CONFIG_WRITE_TIMEOUT);
         byte[] byteContent = content.getBytes();
         TcpClient tcpClient = (TcpClient) client.getNativeData(Constants.CLIENT);
-        tcpClient.writeData(byteContent, balFuture);
+        tcpClient.writeData(byteContent, balFuture, writeTimeOut);
 
         return null;
     }


### PR DESCRIPTION
## Purpose
Introduce write timeout for TCP clients. Timeout will be set when the write operation gets called. If the write operation stays in an idle state for the configured time, it'll return a `Write timed out` error.

Related issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/1684

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests
