### PR TITLE
Migrate Java interop calls to latest ballerina runtime APIs

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/tcp/Dispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/tcp/Dispatcher.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.stdlib.tcp;
 
+import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.MethodType;
@@ -43,8 +44,15 @@ public class Dispatcher {
     private static void invokeOnBytes(TcpService tcpService, ByteBuf buffer, Channel channel, Type[] parameterTypes) {
         try {
             Object[] params = getOnBytesSignature(buffer, channel, tcpService, parameterTypes);
-            tcpService.getRuntime().invokeMethodAsync(tcpService.getConnectionService(), Constants.ON_BYTES, null, null,
-                    new TcpCallback(tcpService, false, channel), params);
+            BObject connService = tcpService.getConnectionService();
+            if (connService.getType().isIsolated() && connService.getType().isIsolated(Constants.ON_BYTES)) {
+                tcpService.getRuntime().invokeMethodAsyncConcurrently(connService, Constants.ON_BYTES, null,
+                        null, new TcpCallback(tcpService, false, channel), null, PredefinedTypes.TYPE_ANY, params);
+            } else {
+                tcpService.getRuntime().invokeMethodAsyncSequentially(connService, Constants.ON_BYTES, null,
+                        null, new TcpCallback(tcpService, false, channel), null,
+                        PredefinedTypes.TYPE_ANY, params);
+            }
         } catch (BError e) {
             Dispatcher.invokeOnError(tcpService, e.getMessage());
         }
@@ -59,8 +67,14 @@ public class Dispatcher {
                     .filter(m -> m.getName().equals(Constants.ON_ERROR)).findFirst().orElse(null);
             if (methodType != null) {
                 Object[] params = getOnErrorSignature(message);
-                tcpService.getRuntime().invokeMethodAsync(tcpService.getConnectionService(), Constants.ON_ERROR,
-                        null, null, new TcpCallback(tcpService), params);
+                BObject connService = tcpService.getConnectionService();
+                if (connService.getType().isIsolated() && connService.getType().isIsolated(Constants.ON_ERROR)) {
+                    tcpService.getRuntime().invokeMethodAsyncConcurrently(connService, Constants.ON_ERROR,
+                            null, null, new TcpCallback(tcpService), null, PredefinedTypes.TYPE_ANY, params);
+                } else {
+                    tcpService.getRuntime().invokeMethodAsyncSequentially(connService, Constants.ON_ERROR,
+                            null, null, new TcpCallback(tcpService), null, PredefinedTypes.TYPE_ANY, params);
+                }
             }
         } catch (Throwable t) {
             log.error("Error while executing onError function", t);
@@ -123,8 +137,14 @@ public class Dispatcher {
     public static void invokeOnConnect(TcpService tcpService, Channel channel) {
         try {
             Object[] params = getOnConnectSignature(channel, tcpService);
-            tcpService.getRuntime().invokeMethodAsync(tcpService.getService(), Constants.ON_CONNECT,
-                    null, null, new TcpCallback(tcpService, true, channel), params);
+            BObject balService = tcpService.getService();
+            if (balService.getType().isIsolated() && balService.getType().isIsolated(Constants.ON_CONNECT)) {
+                tcpService.getRuntime().invokeMethodAsyncConcurrently(balService, Constants.ON_CONNECT,
+                        null, null, new TcpCallback(tcpService, true, channel), null, PredefinedTypes.TYPE_ANY, params);
+            } else {
+                tcpService.getRuntime().invokeMethodAsyncSequentially(balService, Constants.ON_CONNECT,
+                        null, null, new TcpCallback(tcpService, true, channel), null, PredefinedTypes.TYPE_ANY, params);
+            }
         } catch (BError e) {
             Dispatcher.invokeOnError(tcpService, e.getMessage());
         }
@@ -144,8 +164,14 @@ public class Dispatcher {
                     .filter(m -> m.getName().equals(Constants.ON_CLOSE)).findFirst().orElse(null);
             if (methodType != null) {
                 Object[] params = {};
-                tcpService.getRuntime().invokeMethodAsync(tcpService.getConnectionService(), Constants.ON_CLOSE,
-                        null, null, new TcpCallback(), params);
+                BObject balService = tcpService.getConnectionService();
+                if (balService.getType().isIsolated() && balService.getType().isIsolated(Constants.ON_CLOSE)) {
+                    tcpService.getRuntime().invokeMethodAsyncConcurrently(balService, Constants.ON_CLOSE,
+                            null, null, new TcpCallback(), null, PredefinedTypes.TYPE_ANY, params);
+                } else {
+                    tcpService.getRuntime().invokeMethodAsyncSequentially(balService, Constants.ON_CLOSE,
+                            null, null, new TcpCallback(), null, PredefinedTypes.TYPE_ANY, params);
+                }
             }
         } catch (BError e) {
             Dispatcher.invokeOnError(tcpService, e.getMessage());

--- a/native/src/main/java/io/ballerina/stdlib/tcp/Dispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/tcp/Dispatcher.java
@@ -45,7 +45,7 @@ public class Dispatcher {
         try {
             Object[] params = getOnBytesSignature(buffer, channel, tcpService, parameterTypes);
             BObject connService = tcpService.getConnectionService();
-            if (connService.getType().isIsolated() && connService.getType().isIsolated(Constants.ON_BYTES)) {
+            if (isIsolated(connService, Constants.ON_BYTES)) {
                 tcpService.getRuntime().invokeMethodAsyncConcurrently(connService, Constants.ON_BYTES, null,
                         null, new TcpCallback(tcpService, false, channel), null, PredefinedTypes.TYPE_ANY, params);
             } else {
@@ -68,7 +68,7 @@ public class Dispatcher {
             if (methodType != null) {
                 Object[] params = getOnErrorSignature(message);
                 BObject connService = tcpService.getConnectionService();
-                if (connService.getType().isIsolated() && connService.getType().isIsolated(Constants.ON_ERROR)) {
+                if (isIsolated(connService, Constants.ON_ERROR)) {
                     tcpService.getRuntime().invokeMethodAsyncConcurrently(connService, Constants.ON_ERROR,
                             null, null, new TcpCallback(tcpService), null, PredefinedTypes.TYPE_ANY, params);
                 } else {
@@ -138,7 +138,7 @@ public class Dispatcher {
         try {
             Object[] params = getOnConnectSignature(channel, tcpService);
             BObject balService = tcpService.getService();
-            if (balService.getType().isIsolated() && balService.getType().isIsolated(Constants.ON_CONNECT)) {
+            if (isIsolated(balService, Constants.ON_CONNECT)) {
                 tcpService.getRuntime().invokeMethodAsyncConcurrently(balService, Constants.ON_CONNECT,
                         null, null, new TcpCallback(tcpService, true, channel), null, PredefinedTypes.TYPE_ANY, params);
             } else {
@@ -165,7 +165,7 @@ public class Dispatcher {
             if (methodType != null) {
                 Object[] params = {};
                 BObject balService = tcpService.getConnectionService();
-                if (balService.getType().isIsolated() && balService.getType().isIsolated(Constants.ON_CLOSE)) {
+                if (isIsolated(balService, Constants.ON_CLOSE)) {
                     tcpService.getRuntime().invokeMethodAsyncConcurrently(balService, Constants.ON_CLOSE,
                             null, null, new TcpCallback(), null, PredefinedTypes.TYPE_ANY, params);
                 } else {
@@ -176,6 +176,10 @@ public class Dispatcher {
         } catch (BError e) {
             Dispatcher.invokeOnError(tcpService, e.getMessage());
         }
+    }
+
+    private static boolean isIsolated(BObject serviceObj, String remoteMethod) {
+        return serviceObj.getType().isIsolated() && serviceObj.getType().isIsolated(remoteMethod);
     }
 
     private Dispatcher() {}


### PR DESCRIPTION
## Purpose
Related issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/2383
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
