### PR TITLE
Print the stack trace instead of dispatching to `onError` when panicked inside the remote function 

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -41,6 +41,18 @@ modules = [
 
 [[package]]
 org = "ballerina"
+name = "lang.runtime"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.value"
 version = "0.0.0"
 scope = "testOnly"
@@ -56,6 +68,7 @@ dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "test"}
 ]
 modules = [

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -41,18 +41,6 @@ modules = [
 
 [[package]]
 org = "ballerina"
-name = "lang.runtime"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
-]
-
-[[package]]
-org = "ballerina"
 name = "lang.value"
 version = "0.0.0"
 scope = "testOnly"
@@ -68,7 +56,6 @@ dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "test"}
 ]
 modules = [

--- a/ballerina/tests/listener_readonly_test.bal
+++ b/ballerina/tests/listener_readonly_test.bal
@@ -14,8 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
 import ballerina/test;
+import ballerina/lang.runtime as runtime;
 
 boolean isReadOnly = false;
 
@@ -32,7 +32,7 @@ service class TestReadOnlyService {
     remote function onBytes(Caller caller, readonly & byte[] data) returns Error? {
         byte[] bb = data;
         isReadOnly = bb is readonly & byte[];
-        io:println("Echo: ", string:fromBytes(data));
+        byte _ = bb.pop();
         return caller->writeBytes(data);
     }
 }
@@ -43,9 +43,8 @@ function testReadOnlyData() returns error? {
     string msg = "Test ReadOnly";
     byte[] msgByteArray = msg.toBytes();
     check socketClient->writeBytes(msgByteArray);
-    readonly & byte[] res = check socketClient->readBytes();
+    runtime:sleep(2);
     test:assertTrue(isReadOnly);
-    test:assertEquals('string:fromBytes(res), msg);
 
     check socketClient->close();
 }

--- a/ballerina/tests/listener_tests.bal
+++ b/ballerina/tests/listener_tests.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/test;
-import ballerina/lang.runtime as runtime;
 import ballerina/io;
 
 @test:Config {dependsOn: [testServerAlreadyClosed]}
@@ -86,12 +85,4 @@ function testListenerDetach() returns error? {
     receivedData = check socketClient->readBytes();
     test:assertEquals(string:fromBytes(receivedData), "Hi", "Unexpected response");
     test:assertNotEquals(conId, "xx");
-}
-
-@test:Config {dependsOn: [testListenerDetach]}
-function testServiceOnErrorWhenDispatching() returns error? {
-    Client socketClient = check new ("localhost", PORT8);
-    check socketClient->writeBytes("What service is this?".toBytes());
-    runtime:sleep(5);
-    test:assertEquals(onErrorInvoked, true);
 }

--- a/native/src/main/java/io/ballerina/stdlib/tcp/TcpCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/tcp/TcpCallback.java
@@ -66,12 +66,6 @@ public class TcpCallback implements Callback {
 
     @Override
     public void notifyFailure(BError bError) {
-        if (!isOnConnectInvoked) {
-            Dispatcher.invokeOnError(tcpService, bError.getMessage());
-        }
-
-        if (log.isDebugEnabled()) {
-            log.debug(String.format("Method dispatch failed: %s", bError.getMessage()));
-        }
+        bError.printStackTrace();
     }
 }


### PR DESCRIPTION
## Purpose
$subject.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
