### PR TITLE
Remove GraalVM warning logs after updating the Netty version

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -60,3 +60,27 @@ groupId = "io.netty"
 artifactId = "netty-transport-native-unix-common"
 version = "4.1.86.Final"
 path = "./lib/netty-transport-native-unix-common-4.1.86.Final.jar"
+
+[[platform.java11.dependency]]
+groupId = "io.netty"
+artifactId = "netty-codec-socks"
+version = "4.1.86.Final"
+path = "./lib/netty-codec-socks-4.1.86.Final.jar"
+
+[[platform.java11.dependency]]
+groupId = "org.jboss.marshalling"
+artifactId = "jboss-marshalling"
+version = "2.0.5.Final"
+path = "./lib/jboss-marshalling-2.0.5.Final.jar"
+
+[[platform.java11.dependency]]
+groupId = "net.jpountz.lz4"
+artifactId = "lz4"
+version = "1.3.0"
+path = "./lib/lz4-1.3.0.jar"
+
+[[platform.java11.dependency]]
+groupId = "com.google.protobufl"
+artifactId = "protobuf-java"
+version = "3.20.3"
+path = "./lib/protobuf-java-3.20.3.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -95,4 +95,3 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
 
-

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -90,15 +90,33 @@ dependencies {
     externalJars(group: 'io.netty', name: 'netty-transport-native-unix-common', version: "${nettyVersion}") {
         transitive = false
     }
+    externalJars(group: 'io.netty', name: 'netty-codec-socks', version: "${nettyVersion}") {
+        transitive = false
+    }
+    externalJars(group: 'net.jpountz.lz4', name: 'lz4', version: "${lz4Version}") {
+        transitive = false
+    }
+    externalJars(group: 'org.jboss.marshalling', name: 'jboss-marshalling', version: "${marshallingVersion}") {
+        transitive = false
+    }
+    externalJars(group: 'com.google.protobuf', name: 'protobuf-java', version: "${protobufVersion}") {
+        transitive = false
+    }
 }
 
 task updateTomlFiles {
     doLast {
         def nettyVersion = project.nettyVersion
+        def stdlibDependentLz4Version = project.lz4Version
+        def stdlibDependentMarshallingVersion = project.marshallingVersion
+        def stdlibDependentProtobufVersion = project.protobufVersion
 
         def newConfig = ballerinaTomlFilePlaceHolder.text.replace("@project.version@", project.version)
         newConfig = newConfig.replace("@toml.version@", tomlVersion)
         newConfig = newConfig.replace("@netty.version@", nettyVersion)
+        newConfig = newConfig.replace("@lz4.version@", stdlibDependentLz4Version)
+        newConfig = newConfig.replace("@marshalling.version@", stdlibDependentMarshallingVersion)
+        newConfig = newConfig.replace("@protobuf.version@", stdlibDependentProtobufVersion)
         ballerinaTomlFile.text = newConfig
 
         def newPluginConfig = compilerPluginTomlFilePlaceHolder.text.replace("@project.version@", project.version)

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -60,3 +60,27 @@ groupId = "io.netty"
 artifactId = "netty-transport-native-unix-common"
 version = "@netty.version@"
 path = "./lib/netty-transport-native-unix-common-@netty.version@.jar"
+
+[[platform.java11.dependency]]
+groupId = "io.netty"
+artifactId = "netty-codec-socks"
+version = "@netty.version@"
+path = "./lib/netty-codec-socks-@netty.version@.jar"
+
+[[platform.java11.dependency]]
+groupId = "org.jboss.marshalling"
+artifactId = "jboss-marshalling"
+version = "@marshalling.version@"
+path = "./lib/jboss-marshalling-@marshalling.version@.jar"
+
+[[platform.java11.dependency]]
+groupId = "net.jpountz.lz4"
+artifactId = "lz4"
+version = "@lz4.version@"
+path = "./lib/lz4-@lz4.version@.jar"
+
+[[platform.java11.dependency]]
+groupId = "com.google.protobufl"
+artifactId = "protobuf-java"
+version = "@protobuf.version@"
+path = "./lib/protobuf-java-@protobuf.version@.jar"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ ballerinaGradlePluginVersion=1.0.0
 gsonVersion=2.8.8
 lz4Version=1.3.0
 marshallingVersion=2.0.5.Final
-protobufVersion=2.6.1
+protobufVersion=3.20.3
 
 # Dependencies
 stdlibIoVersion=1.4.0-20230103-173700-287bb2e

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,9 @@ researchgateReleaseVersion=2.8.0
 slf4jVersion=1.7.30
 ballerinaGradlePluginVersion=1.0.0
 gsonVersion=2.8.8
+lz4Version=1.3.0
+marshallingVersion=2.0.5.Final
+protobufVersion=2.6.1
 
 # Dependencies
 stdlibIoVersion=1.4.0-20230103-173700-287bb2e


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/3889

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [x] Checked native-image compatibility
