### PR TITLE
Wrap SSL context errors with a clear message

### DIFF
--- a/ballerina/tests/secure_listener_test.bal
+++ b/ballerina/tests/secure_listener_test.bal
@@ -198,3 +198,26 @@ function testListenerWithEmptyCiphers() returns error? {
         test:assertFail(msg = "Without Ciphers. Should work");
     }
 }
+
+// Regression: a non-PKCS12 file at `key.path` used to leak the underlying
+// ASN.1 parser message (e.g. "Tag number over 30 is not supported") or NPE
+// when the parser threw an exception with a null message. The error must now
+// be wrapped with a "Failed to initialize the SSL context" prefix.
+@test:Config {}
+function testListenerWithMalformedKeystore() returns error? {
+    Listener server = check new Listener(9999, secureSocket = {
+        key: {
+            path: certPath,
+            password: "ballerina"
+        }
+    });
+
+    check server.attach(obj);
+    error? res = server.start();
+    if res is error {
+        test:assertTrue(res.message().startsWith("Failed to initialize the SSL context"),
+                msg = "Expected wrapped SSL init error, got: " + res.message());
+    } else {
+        test:assertFail(msg = "Malformed keystore should fail to initialize.");
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [Address `CVE-2026-33870` and `CVE-2026-33871` Netty vulnerability in Standard Libraries](https://github.com/ballerina-platform/ballerina-library/issues/8738)
-- [Surface a clear error when the SSL keystore/truststore file is invalid](https://github.com/wso2/product-integrator/issues/1181)
+- [Surface a clear error when the SSL keystore/truststore file is invalid](https://github.com/ballerina-platform/ballerina-library/issues/8766)
 
 ## [1.13.3] - 2026-01-09
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [Address `CVE-2026-33870` and `CVE-2026-33871` Netty vulnerability in Standard Libraries](https://github.com/ballerina-platform/ballerina-library/issues/8738)
+- [Surface a clear error when the SSL keystore/truststore file is invalid](https://github.com/wso2/product-integrator/issues/1181)
 
 ## [1.13.3] - 2026-01-09
 

--- a/native/src/main/java/io/ballerina/stdlib/tcp/SSLHandlerFactory.java
+++ b/native/src/main/java/io/ballerina/stdlib/tcp/SSLHandlerFactory.java
@@ -124,7 +124,7 @@ public class SSLHandlerFactory {
         }
     }
 
-    public SslContext createContextForClient() throws IOException, NoSuchAlgorithmException, KeyStoreException {
+    public SslContext createContextForClient() throws IOException {
         try {
             SslProvider provider = SslProvider.JDK;
             SslContextBuilder sslContextBuilder;
@@ -156,8 +156,7 @@ public class SSLHandlerFactory {
         tmf.init(tks);
     }
 
-    public SslContext createContextForServer() throws IOException, NoSuchAlgorithmException, UnrecoverableKeyException,
-            KeyStoreException {
+    public SslContext createContextForServer() throws IOException {
         try {
             SslProvider provider = SslProvider.JDK;
             SslContextBuilder sslContextBuilder;

--- a/native/src/main/java/io/ballerina/stdlib/tcp/SSLHandlerFactory.java
+++ b/native/src/main/java/io/ballerina/stdlib/tcp/SSLHandlerFactory.java
@@ -125,25 +125,29 @@ public class SSLHandlerFactory {
     }
 
     public SslContext createContextForClient() throws IOException, NoSuchAlgorithmException, KeyStoreException {
-        SslProvider provider = SslProvider.JDK;
-        SslContextBuilder sslContextBuilder;
-        if (sslConfig.getClientTrustCertificates() != null) {
-            sslContextBuilder = clientContextBuilderWithCerts(provider);
-        } else {
-            initializeTrustManagerFactory();
-            sslContextBuilder = clientContextBuilderWithKs(provider);
+        try {
+            SslProvider provider = SslProvider.JDK;
+            SslContextBuilder sslContextBuilder;
+            if (sslConfig.getClientTrustCertificates() != null) {
+                sslContextBuilder = clientContextBuilderWithCerts(provider);
+            } else {
+                initializeTrustManagerFactory();
+                sslContextBuilder = clientContextBuilderWithKs(provider);
+            }
+            String[] ciphers = this.sslConfig.getCipherSuites();
+            if (ciphers != null) {
+                setCiphers(sslContextBuilder, Arrays.asList(ciphers));
+            }
+            setSslProtocol(sslContextBuilder);
+            SslContext sslContext = sslContextBuilder.build();
+            int sessionTimeout = sslConfig.getSessionTimeOut();
+            if (sessionTimeout > 0) {
+                sslContext.sessionContext().setSessionTimeout(sessionTimeout);
+            }
+            return sslContext;
+        } catch (IOException | NoSuchAlgorithmException | KeyStoreException e) {
+            throw new IOException("Failed to initialize the SSL context: " + describe(e), e);
         }
-        String[] ciphers = this.sslConfig.getCipherSuites();
-        if (ciphers != null) {
-            setCiphers(sslContextBuilder, Arrays.asList(ciphers));
-        }
-        setSslProtocol(sslContextBuilder);
-        SslContext sslContext = sslContextBuilder.build();
-        int sessionTimeout = sslConfig.getSessionTimeOut();
-        if (sessionTimeout > 0) {
-            sslContext.sessionContext().setSessionTimeout(sessionTimeout);
-        }
-        return sslContext;
     }
 
     private void initializeTrustManagerFactory() throws IOException, NoSuchAlgorithmException, KeyStoreException {
@@ -154,25 +158,29 @@ public class SSLHandlerFactory {
 
     public SslContext createContextForServer() throws IOException, NoSuchAlgorithmException, UnrecoverableKeyException,
             KeyStoreException {
-        SslProvider provider = SslProvider.JDK;
-        SslContextBuilder sslContextBuilder;
-        if (sslConfig.getServerCertificates() != null) {
-            sslContextBuilder = serverContextBuilderWithCerts(provider);
-        } else {
-            initializeKeyManagerFactory();
-            sslContextBuilder = serverContextBuilderWithKs(provider);
+        try {
+            SslProvider provider = SslProvider.JDK;
+            SslContextBuilder sslContextBuilder;
+            if (sslConfig.getServerCertificates() != null) {
+                sslContextBuilder = serverContextBuilderWithCerts(provider);
+            } else {
+                initializeKeyManagerFactory();
+                sslContextBuilder = serverContextBuilderWithKs(provider);
+            }
+            String[] ciphers = this.sslConfig.getCipherSuites();
+            if (ciphers != null) {
+                setCiphers(sslContextBuilder, Arrays.asList(ciphers));
+            }
+            setSslProtocol(sslContextBuilder);
+            SslContext sslContext = sslContextBuilder.build();
+            int sessionTimeout = sslConfig.getSessionTimeOut();
+            if (sessionTimeout > 0) {
+                sslContext.sessionContext().setSessionTimeout(sessionTimeout);
+            }
+            return sslContext;
+        } catch (IOException | NoSuchAlgorithmException | UnrecoverableKeyException | KeyStoreException e) {
+            throw new IOException("Failed to initialize the SSL context: " + describe(e), e);
         }
-        String[] ciphers = this.sslConfig.getCipherSuites();
-        if (ciphers != null) {
-            setCiphers(sslContextBuilder, Arrays.asList(ciphers));
-        }
-        setSslProtocol(sslContextBuilder);
-        SslContext sslContext = sslContextBuilder.build();
-        int sessionTimeout = sslConfig.getSessionTimeOut();
-        if (sessionTimeout > 0) {
-            sslContext.sessionContext().setSessionTimeout(sessionTimeout);
-        }
-        return sslContext;
     }
 
     private void initializeKeyManagerFactory() throws IOException, NoSuchAlgorithmException, KeyStoreException,
@@ -183,5 +191,9 @@ public class SSLHandlerFactory {
         kmf.init(ks, sslConfig.getCertPass() != null ?
                 sslConfig.getCertPass().toCharArray() :
                 sslConfig.getKeyStorePass().toCharArray());
+    }
+
+    private static String describe(Throwable t) {
+        return t.getMessage() != null ? t.getMessage() : t.getClass().getSimpleName();
     }
 }


### PR DESCRIPTION
## Purpose

Refs wso2/product-integrator#1181

When the keystore/truststore file passed to a `tcp:Listener` (or `tcp:Client`) `secureSocket` config isn't a valid PKCS12/JKS file, users see one of two unhelpful failures at listener startup:

```
error: Tag number over 30 is not supported
```

or, when the underlying parser exception has a null message:

```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke
"io.ballerina.runtime.api.values.BString.getValue()" because "this.message" is null
    at io.ballerina.runtime.internal.values.ErrorValue.getPrintableError(ErrorValue.java:411)
    at io.ballerina.runtime.internal.utils.RuntimeUtils.handleFutureAndExit(RuntimeUtils.java:77)
```

## Root cause

`SSLHandlerFactory.getKeyStore` only catches `CertificateException`, `NoSuchAlgorithmException`, and `KeyStoreException`. `KeyStore.load` also throws plain `IOException` (the JDK's `sun.security.util.DerValue` parser, invoked via `PKCS12KeyStore.engineLoad`, throws `IOException` on a malformed DER tag), and that path goes uncaught. The exception bubbles out of `TcpListener.initChannel`, Netty hands it to `exceptionCaught`, which calls:

```java
callback.complete(Utils.createTcpError(cause.getMessage()));
```

So the user sees the raw parser message — or, when `cause.getMessage()` is `null`, the Ballerina runtime crashes constructing the error.

## Fix

Mirror `module-ballerina-http`'s pattern — `SSLHandlerFactory.createSSLContextFromKeystores` wraps its body in a `try`/`catch` that catches `IOException` (and the rest of the keystore/SSL exception family) and rethrows with a `Failed to initialize the SSLContext: ...` prefix. Apply the same wrapping to `createContextForClient` and `createContextForServer` here, plus a small helper that substitutes the exception's class name when `getMessage()` is null so the runtime never sees a null `BString`.

After the fix:

```
error: Failed to initialize the SSL context: Tag number over 30 is not supported
```

## Test

Added `testListenerWithMalformedKeystore` in `secure_listener_test.bal`: points `key.path` at the existing `tests/etc/cert.pem` (a valid file that is not a valid PKCS12 keystore) and asserts the error starts with the wrapped prefix.

## Reproducer

A standalone reproducer that exhibits the original error on the unfixed module is at https://github.com/wso2/product-integrator/issues/1181.

## Checklist

- [x] Bug fix
- [x] Test case added
- [x] Changelog updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request improves error handling and messaging when invalid keystore or truststore files are passed to TCP listeners and clients. Previously, users encountered raw parser error messages or runtime crashes when invalid files were provided. This PR wraps SSL context creation errors with clear, informative messages to help developers quickly diagnose configuration issues.

## Changes

**Error Handling Enhancement** (`SSLHandlerFactory.java`)
- Refactored `createContextForClient()` and `createContextForServer()` to wrap SSL context creation logic in try-catch blocks
- Added exception handling that catches I/O errors and keystore-related exceptions and rethrows them with a descriptive `"Failed to initialize the SSL context:"` prefix
- Implemented a helper method to ensure meaningful error messages are always provided, preventing null reference issues during error reporting

**Test Coverage** (`secure_listener_test.bal`)
- Added `testListenerWithMalformedKeystore()` test case to verify that listeners properly report errors when initialized with invalid keystore files
- Test confirms that error messages surface with the expected prefix

**Documentation** (`changelog.md`)
- Updated changelog to document the improved error reporting for invalid SSL keystore/truststore files

## Outcome

Users now receive clear, actionable error messages when SSL context initialization fails, improving the debugging experience and reducing time spent troubleshooting configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
