### PR TITLE
Update Netty version

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -25,50 +25,50 @@ scope = "testOnly"
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-handler"
-version = "4.1.135.Final"
-path = "./lib/netty-handler-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-handler-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-buffer"
-version = "4.1.135.Final"
-path = "./lib/netty-buffer-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-buffer-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport"
-version = "4.1.135.Final"
-path = "./lib/netty-transport-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-transport-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-common"
-version = "4.1.135.Final"
-path = "./lib/netty-common-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-common-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver"
-version = "4.1.135.Final"
-path = "./lib/netty-resolver-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-resolver-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec"
-version = "4.1.135.Final"
-path = "./lib/netty-codec-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-codec-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-unix-common"
-version = "4.1.135.Final"
-path = "./lib/netty-transport-native-unix-common-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-transport-native-unix-common-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec-socks"
-version = "4.1.135.Final"
-path = "./lib/netty-codec-socks-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-codec-socks-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.jboss.marshalling"

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@ This file contains all the notable changes done to the Ballerina TCP package thr
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Update Netty version to 4.1.133-Final](https://github.com/ballerina-platform/ballerina-library/issues/8924)
+
 ## [1.13.6] - 2026-05-11
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- [Update Netty version to 4.1.133-Final](https://github.com/ballerina-platform/ballerina-library/issues/8924)
+- [Update Netty version to 4.1.136-Final](https://github.com/ballerina-platform/ballerina-library/issues/8924)
 
 ## [1.13.6] - 2026-05-11
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0
 
 testngVersion=7.6.1
-nettyVersion=4.1.135.Final
+nettyVersion=4.1.136.Final
 slf4jVersion=1.7.30
 gsonVersion=2.8.8
 lz4Version=1.10.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,9 +19,9 @@ marshallingVersion=2.0.5.Final
 protobufVersion=3.25.5
 
 # Dependencies
-stdlibIoVersion=1.8.0
+stdlibIoVersion=1.8.1
 stdlibLogVersion=2.12.0
-stdlibCryptoVersion=2.9.0
+stdlibCryptoVersion=2.9.3
 stdlibTimeVersion=2.7.0
 observeVersion=1.5.0
 observeInternalVersion=1.5.0


### PR DESCRIPTION
## Purpose

> $Subject

Part of https://github.com/ballerina-platform/ballerina-library/issues/8924

Trivy Scan: https://github.com/ballerina-platform/module-ballerina-tcp/actions/runs/30067533934/job/89401325819

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the specification~
- [x] Updated the changelog
- [x] Added tests
- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated Netty dependencies and native JAR references from `4.1.135.Final` to `4.1.136.Final`.
- Updated standard library dependency versions for I/O and cryptography.
- Added an unreleased changelog entry documenting the Netty update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->