### PR TITLE
Update Netty version

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -25,50 +25,50 @@ scope = "testOnly"
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-handler"
-version = "4.1.136.Final"
-path = "./lib/netty-handler-4.1.136.Final.jar"
+version = "4.1.137.Final"
+path = "./lib/netty-handler-4.1.137.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-buffer"
-version = "4.1.136.Final"
-path = "./lib/netty-buffer-4.1.136.Final.jar"
+version = "4.1.137.Final"
+path = "./lib/netty-buffer-4.1.137.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport"
-version = "4.1.136.Final"
-path = "./lib/netty-transport-4.1.136.Final.jar"
+version = "4.1.137.Final"
+path = "./lib/netty-transport-4.1.137.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-common"
-version = "4.1.136.Final"
-path = "./lib/netty-common-4.1.136.Final.jar"
+version = "4.1.137.Final"
+path = "./lib/netty-common-4.1.137.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver"
-version = "4.1.136.Final"
-path = "./lib/netty-resolver-4.1.136.Final.jar"
+version = "4.1.137.Final"
+path = "./lib/netty-resolver-4.1.137.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec"
-version = "4.1.136.Final"
-path = "./lib/netty-codec-4.1.136.Final.jar"
+version = "4.1.137.Final"
+path = "./lib/netty-codec-4.1.137.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-unix-common"
-version = "4.1.136.Final"
-path = "./lib/netty-transport-native-unix-common-4.1.136.Final.jar"
+version = "4.1.137.Final"
+path = "./lib/netty-transport-native-unix-common-4.1.137.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec-socks"
-version = "4.1.136.Final"
-path = "./lib/netty-codec-socks-4.1.136.Final.jar"
+version = "4.1.137.Final"
+path = "./lib/netty-codec-socks-4.1.137.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.jboss.marshalling"

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@ This file contains all the notable changes done to the Ballerina TCP package thr
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Update Netty version to 4.1.137.Final](https://github.com/ballerina-platform/ballerina-library/issues/9093)
+
 ## [1.13.8] - 2026-07-27
 
 - [Update lz4-java to 1.11.1 to fix CVE-2026-59949](https://github.com/ballerina-platform/ballerina-library/issues/8933)

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0
 
 testngVersion=7.6.1
-nettyVersion=4.1.136.Final
+nettyVersion=4.1.137.Final
 slf4jVersion=1.7.30
 gsonVersion=2.8.8
 lz4Version=1.11.1


### PR DESCRIPTION
## Purpose

Update Netty to `4.1.137.Final`.

### Vulnerability fix

`netty-codec-http` `4.1.136.Final` is affected by [`CVE-2026-59903`](https://avd.aquasec.com/nvd/cve-2026-59903) (MEDIUM), fixed in Netty `4.1.137.Final`.

Part of ballerina-platform/ballerina-library#9093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated all Netty dependencies from `4.1.136.Final` to `4.1.137.Final`.
- Updated the related local JAR paths and Gradle version property.
- Documented the dependency update in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->